### PR TITLE
[feature] 회의 입장 시 닉네임 작성 기능 및 회의록 퇴장 기능 구현

### DIFF
--- a/client/src/services/MeetingSocket/CollaborativeEditor.css
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.css
@@ -1,4 +1,56 @@
-/* 기본적인 페이지 스타일 */
+/* 기존 모달 및 기본 스타일 */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    text-align: center;
+    width: 300px;
+}
+
+.modal-content h2 {
+    text-align: center;
+    margin-bottom: 16px;
+}
+
+.modal-content input {
+    text-align: center;
+    width: 100%;
+    padding: 8px;
+    margin-bottom: 16px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.modal-content button {
+    background-color: #4caf50;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.modal-content button:hover {
+    background-color: #45a049;
+}
+
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: #f1f5f9;
@@ -7,8 +59,8 @@ body {
     margin: 0;
 }
 
-/* 전체 컨테이너 */
 .container {
+    flex-direction: row; /* 왼쪽-오른쪽 섹션 나열 */
     width: 80%;
     max-width: 900px;
     margin: 0 auto;
@@ -17,13 +69,100 @@ body {
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.1);
     border-radius: 10px;
     transition: all 0.3s ease;
+    display: flex; /* 컨테이너에 Flexbox 적용 */
+    justify-content: space-between; /* 영역 간 간격 조정 */
+    gap: 20px; /* 두 섹션 간 간격 추가 */
 }
 
 .container:hover {
     box-shadow: 0 0 25px rgba(0, 0, 0, 0.2);
 }
 
-/* 헤더 스타일 */
+/* 참여 메시지를 박스로 분리 */
+.participants-box {
+    width: 20%; /* 적절한 너비 설정 */
+    background-color: #f9f9f9;
+    padding: 15px;
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+.participants-box h2 {
+    font-size: 1.2em;
+    margin-bottom: 10px;
+    color: #4caf50;
+    text-align: center;
+}
+
+.participants-box ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.participants-box li {
+    font-size: 0.9em;
+    margin-bottom: 8px;
+    color: #555;
+}
+
+.collaborative-editor {
+    display: flex;
+    flex-direction: row;
+    gap: 20px; /* 섹션 간 간격 */
+    padding: 20px;
+}
+
+.participants-section {
+    width: 30%; /* 좌측 박스 비율 */
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 10px;
+    background-color: #f9f9f9;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.participants-section ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+
+.editor-section {
+    width: 70%; /* 우측 박스 비율 */
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 15px;
+    background-color: #ffffff;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+/* 왼쪽 섹션 */
+.left-section {
+    width: 25%;
+}
+
+/* 오른쪽 섹션 */
+.right-section {
+    width: 75%;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* 닉네임 및 메시지 목록 */
+.nickname-messages ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.nickname-messages li {
+    margin-bottom: 8px;
+    font-size: 14px;
+    color: #333;
+}
+
 h1 {
     text-align: center;
     color: #4caf50;
@@ -33,7 +172,6 @@ h1 {
     letter-spacing: 2px;
 }
 
-/* 회의 정보 섹션 */
 .meeting-info {
     display: flex;
     justify-content: space-between;
@@ -64,7 +202,6 @@ h1 {
     border-color: #4caf50;
 }
 
-/* 각 섹션 스타일 */
 .agenda-section, .notes-section, .results-section {
     margin-top: 20px;
     padding: 10px;
@@ -78,7 +215,6 @@ h1 {
     margin-bottom: 15px;
 }
 
-/* 텍스트 영역 스타일 */
 textarea {
     width: 100%;
     box-sizing: border-box;
@@ -111,7 +247,6 @@ textarea:focus {
     background-color: #f0f9f4;
 }
 
-/* 버튼 스타일 */
 .save-button {
     display: block;
     margin: 20px auto 0;
@@ -140,11 +275,11 @@ textarea:focus {
     box-shadow: 0 0 0 4px rgba(76, 175, 80, 0.3);
 }
 
-/* 작은 화면에서 스타일 조정 */
 @media screen and (max-width: 768px) {
     .container {
         width: 95%;
         padding: 15px;
+        flex-direction: column; /* 작은 화면에서는 세로로 배치 */
     }
 
     h1 {

--- a/client/src/services/MeetingSocket/CollaborativeEditor.css
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.css
@@ -12,6 +12,56 @@
     z-index: 1000;
 }
 
+/* 전체 섹션 스타일 */
+.participants-section {
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    background-color: #f9f9f9;
+    max-width: 600px;
+    margin: 20px auto;
+}
+
+/* 메시지 박스 스타일 */
+.participant-messages {
+    margin-bottom: 20px;
+}
+
+.participant-message {
+    background: linear-gradient(135deg, #4caf50, #81c784);
+    color: white;
+    padding: 10px;
+    margin: 5px 0;
+    border-radius: 8px;
+    animation: fadeIn 0.6s ease-out;
+}
+
+/* 참여자 목록 스타일 */
+.participant-list {
+    list-style: none;
+    padding: 0;
+}
+
+.participant-list li {
+    background: #f1f1f1;
+    margin: 5px 0;
+    padding: 10px;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* 애니메이션 */
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .modal-content {
     display: flex;
     flex-direction: column;
@@ -113,6 +163,7 @@ body {
 }
 
 .participants-section {
+    text-align: center;
     width: 30%; /* 좌측 박스 비율 */
     border: 1px solid #ccc;
     border-radius: 8px;
@@ -172,19 +223,25 @@ h1 {
     letter-spacing: 2px;
 }
 
+/* 기존 meeting-info 섹션을 수정 */
 .meeting-info {
     display: flex;
-    justify-content: space-between;
+    justify-content: space-between; /* 좌우 간격 */
+    align-items: center; /* 세로 정렬 */
     margin-bottom: 20px;
 }
 
+/* 회의 날짜 레이블 */
 .meeting-info label {
+    display: inline-block;  /* 한 줄로 표시되도록 inline-block으로 설정 */
     font-weight: 600;
     color: #444;
-    display: flex;
-    align-items: center;
+    font-size: 1.1em;
+    white-space: nowrap;  /* 텍스트가 줄 바꿈 없이 한 줄로 표시되도록 설정 */
+    margin-left: 130px;
 }
 
+/* date 및 text input 스타일 */
 .meeting-info input[type="date"],
 .meeting-info input[type="text"] {
     margin-left: 10px;
@@ -193,14 +250,69 @@ h1 {
     border-radius: 8px;
     border: 1px solid #ccc;
     background-color: #fafafa;
-    width: 60%;
+    width: 60%; /* 날짜 입력 부분 너비 설정 */
     transition: border-color 0.3s ease;
 }
 
+
+/* 날짜 입력 필드에 포커스 시 스타일 변경 */
 .meeting-info input[type="date"]:focus,
 .meeting-info input[type="text"]:focus {
     border-color: #4caf50;
 }
+
+/* 참여자 목록 토글 버튼 */
+.toggle-participants {
+
+    background: #f4f4f4;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    color: #333;
+    padding: 8px 15px;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.3s ease;
+    margin-right: 310px;
+}
+
+/* 토글 버튼 hover 시 색상 변화 */
+.toggle-participants:hover {
+    background-color: #92d795;
+}
+
+/* 참여자 목록 섹션 */
+.participants-section2 {
+    margin-top: 10px; /* 버튼과 목록 사이의 간격 */
+    padding: 15px;
+    background-color: #bff9ce;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(2, 0, 0, 0.1);
+    margin-right: 400px;
+}
+
+/* 참여자 목록 컨테이너 */
+.participant-list-container {
+    max-height: 200px; /* 최대 높이를 설정 */
+    overflow-y: auto;  /* 내용이 넘칠 경우 스크롤 활성화 */
+    padding-right: 10px;  /* 오른쪽 여백을 줘서 스크롤이 겹치지 않도록 함 */
+}
+
+/* 참여자 목록 스타일 */
+.participant-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.participant-list li {
+    background: #f1f1f1;
+    margin: 5px 0;
+    padding: 10px;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
 
 .agenda-section, .notes-section, .results-section {
     margin-top: 20px;
@@ -293,4 +405,6 @@ textarea:focus {
     .meeting-info label {
         font-size: 0.9em;
     }
+
+    
 }

--- a/client/src/services/MeetingSocket/CollaborativeEditor.css
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.css
@@ -387,6 +387,27 @@ textarea:focus {
     box-shadow: 0 0 0 4px rgba(76, 175, 80, 0.3);
 }
 
+/* 나가기 버튼 스타일 */
+.leave-button {
+    background-color: #ff4d4f;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    font-size: 16px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.leave-button:hover {
+    background-color: #e04345;
+}
+
+.leave-button:active {
+    background-color: #c03638;
+}
+
+
 @media screen and (max-width: 768px) {
     .container {
         width: 95%;

--- a/client/src/services/MeetingSocket/CollaborativeEditor.js
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.js
@@ -17,8 +17,9 @@ function CollaborativeEditor() {
     // 닉네임 변경 처리 및 참여 상태 갱신
     useEffect(() => {
         if (nicknameInput.trim() !== '') {
+            // 웹소켓 연결
             ws.current = new WebSocket("ws://localhost:8080/socket/meeting");
-
+    
             ws.current.onmessage = (event) => {
                 try {
                     const message = JSON.parse(event.data);
@@ -52,13 +53,13 @@ function CollaborativeEditor() {
                     }
                 }
             };
-
+    
             ws.current.onclose = () => console.log("WebSocket connection closed");
-
+    
             return () => ws.current.close();
         }
     }, [nicknameInput]);
-
+    
     // 닉네임 설정 후 참여 상태 갱신
     const handleModalSubmit = () => {
         if (nicknameInput.trim() && ws.current.readyState === WebSocket.OPEN) {
@@ -69,7 +70,7 @@ function CollaborativeEditor() {
             ws.current.send(`nickname:${nicknameInput.trim()}`);
             setIsModalOpen(false);
         }
-    };
+    };    
 
     const sendMessage = (content, type) => {
         if (ws.current.readyState === WebSocket.OPEN) {

--- a/client/src/services/MeetingSocket/CollaborativeEditor.js
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.js
@@ -9,25 +9,44 @@ function CollaborativeEditor() {
     const [nicknameInput, setNicknameInput] = useState('');
     const [nicknameMessages, setNicknameMessages] = useState([]);
     const [isModalOpen, setIsModalOpen] = useState(true);
+    const [isParticipantsListVisible, setIsParticipantsListVisible] = useState(false); // 토글 상태 추가
     const ws = useRef(null);
     const debounceTimeout = useRef(null);
 
     useEffect(() => {
         ws.current = new WebSocket("ws://localhost:8080/socket/meeting");
-
+    
         ws.current.onmessage = (event) => {
-            const message = event.data;
-            if (message.startsWith("nicknames:")) {
-                const nicknameList = message.substring(10).split(", ");
-                const newMessages = nicknameList.map((nickname) => `${nickname}님이 회의에 참여하였습니다.`);
-                setNicknameMessages(newMessages);
+            try {
+                const message = JSON.parse(event.data);
+                if (message.type === "agenda") setAgenda(message.content);
+                else if (message.type === "notes") setNotes(message.content);
+                else if (message.type === "results") setResults(message.content);
+            } catch (error) {
+                // JSON 파싱 실패한 메시지 처리
+                if (event.data.startsWith("nicknames:")) {
+                    const nicknameList = event.data.substring(10).split(", ");
+                    setNicknameMessages((prevMessages) => {
+                        // 1. 기존 닉네임만 추출
+                        const existingNicknames = prevMessages;
+    
+                        // 2. 새로운 닉네임 중 중복되지 않은 닉네임만 추가
+                        const uniqueNicknames = nicknameList.filter(
+                            (nickname) => !existingNicknames.includes(nickname)
+                        );
+    
+                        // 3. 기존 메시지에 새로운 닉네임 추가
+                        return [...prevMessages, ...uniqueNicknames];
+                    });
+                } else {
+                    console.error("Unrecognized message format:", event.data);
+                }
             }
         };
-
+    
         ws.current.onclose = () => console.log("WebSocket connection closed");
-
         return () => ws.current.close();
-    }, []);
+    }, []);    
 
     const handleModalSubmit = () => {
         if (nicknameInput.trim() && ws.current.readyState === WebSocket.OPEN) {
@@ -36,17 +55,52 @@ function CollaborativeEditor() {
         }
     };    
 
+    const sendMessage = (content, type) => {
+        if (ws.current.readyState === WebSocket.OPEN) {
+            const message = JSON.stringify({ type, content });
+            ws.current.send(message);
+        }
+    };
+
+    const handleKeyDown = (event, type) => {
+        if (event.key === 'Enter' && event.nativeEvent.isComposing === false) {
+            const content = event.target.value;
+            sendMessage(content, type);
+
+            if (type === "agenda") setAgenda(content);
+            else if (type === "notes") setNotes(content);
+            else if (type === "results") setResults(content);
+        }
+    };
+
+    const handleChange = (event, type) => {
+        const updatedText = event.target.value;
+
+        if (type === "agenda") setAgenda(updatedText);
+        else if (type === "notes") setNotes(updatedText);
+        else if (type === "results") setResults(updatedText);
+
+        if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
+
+        debounceTimeout.current = setTimeout(() => {
+            sendMessage(updatedText, type);
+        }, 200);
+    };
+
+    const toggleParticipantsList = () => {
+        setIsParticipantsListVisible(prevState => !prevState); // 토글 상태 변경
+    };
+
     return (
         <div className="collaborative-editor">
-            {/* 참여 메시지 섹션 */}
+            {/* 회의 참여자 섹션 */}
             <section className="participants-section">
-                <h4>참여 메시지</h4>
-                <ul>
-                    {nicknameMessages.map((msg, index) => (
-                        <li key={index}>{msg}</li>
+                <h2>회의 참여 상태</h2>
+                <ul className="participant-list">
+                    {nicknameMessages.map((nickname, index) => (
+                        <li key={index}>{`${nickname}님이 회의에 참여하였습니다.`}</li>
                     ))}
                 </ul>
-                <br></br>
             </section>
 
             {/* 회의록 섹션 */}
@@ -54,20 +108,41 @@ function CollaborativeEditor() {
                 <h1>회의록📋</h1>
                 <div className="meeting-info">
                     <label>
-                        <strong>📅 회의 날짜:</strong>
+                        <strong>📅 회의 날짜 :</strong>
                         <input
                             type="date"
                             value={meetingDate}
                             onChange={(e) => setMeetingDate(e.target.value)}
                         />
                     </label>
+                    <label>
+                        <strong>👀 참여자 목록 : </strong>
+                        <button className="toggle-participants" onClick={toggleParticipantsList}>
+                            {isParticipantsListVisible ? '참여자 목록 숨기기' : '참여자 목록 보기'}
+                        </button>
+                    </label>
                 </div>
+
+                {/* 회의 참여자 목록 섹션 */}
+                {isParticipantsListVisible && (
+                    <section className="participants-section">
+                        <div className="participant-list-container">
+                            <ul className="participant-list">
+                                {nicknameMessages.map((nickname, index) => (
+                                    <li key={index}>{nickname}님</li>
+                                ))}
+                            </ul>
+                        </div>
+                    </section>
+                )}
 
                 <div className="agenda-section">
                     <h3>🌱 회의 안건</h3>
                     <textarea
+                        data-type="agenda"
                         value={agenda}
-                        onChange={(e) => setAgenda(e.target.value)}
+                        onChange={(e) => handleChange(e, "agenda")}
+                        onKeyDown={(e) => handleKeyDown(e, "agenda")}
                         placeholder="회의 안건을 여기에 작성하세요!"
                         rows="6"
                     />
@@ -76,8 +151,10 @@ function CollaborativeEditor() {
                 <div className="notes-section">
                     <h3>✏️ 회의록</h3>
                     <textarea
+                        data-type="notes"
                         value={notes}
-                        onChange={(e) => setNotes(e.target.value)}
+                        onChange={(e) => handleChange(e, "notes")}
+                        onKeyDown={(e) => handleKeyDown(e, "notes")}
                         placeholder="회의 내용을 여기에 작성하세요!"
                         rows="12"
                     />
@@ -86,8 +163,10 @@ function CollaborativeEditor() {
                 <div className="results-section">
                     <h3>☑️ 회의 결과</h3>
                     <textarea
+                        data-type="results"
                         value={results}
-                        onChange={(e) => setResults(e.target.value)}
+                        onChange={(e) => handleChange(e, "results")}
+                        onKeyDown={(e) => handleKeyDown(e, "results")}
                         placeholder="회의 결과를 여기에 작성하세요!"
                         rows="12"
                     />

--- a/client/src/services/MeetingSocket/CollaborativeEditor.js
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.js
@@ -6,115 +6,110 @@ function CollaborativeEditor() {
     const [notes, setNotes] = useState('');
     const [results, setResults] = useState('');
     const [meetingDate, setMeetingDate] = useState(new Date().toISOString().slice(0, 10));
-    const [attendees, setAttendees] = useState('');
+    const [nicknameInput, setNicknameInput] = useState('');
+    const [nicknameMessages, setNicknameMessages] = useState([]);
+    const [isModalOpen, setIsModalOpen] = useState(true);
     const ws = useRef(null);
-    const debounceTimeout = useRef(null); // WebSocket 전송 지연 시간
+    const debounceTimeout = useRef(null);
 
     useEffect(() => {
         ws.current = new WebSocket("ws://localhost:8080/socket/meeting");
 
         ws.current.onmessage = (event) => {
-            const message = JSON.parse(event.data);
-            if (message.type === "agenda") setAgenda(message.content);
-            else if (message.type === "notes") setNotes(message.content);
-            else if (message.type === "results") setResults(message.content);
+            const message = event.data;
+            if (message.startsWith("nicknames:")) {
+                const nicknameList = message.substring(10).split(", ");
+                const newMessages = nicknameList.map((nickname) => `${nickname}님이 회의에 참여하였습니다.`);
+                setNicknameMessages(newMessages);
+            }
         };
 
         ws.current.onclose = () => console.log("WebSocket connection closed");
+
         return () => ws.current.close();
     }, []);
-    const sendMessage = (content, type) => {
-        if (ws.current.readyState === WebSocket.OPEN) {
-            const message = JSON.stringify({ type, content });
-            ws.current.send(message);
+
+    const handleModalSubmit = () => {
+        if (nicknameInput.trim() && ws.current.readyState === WebSocket.OPEN) {
+            ws.current.send(`nickname:${nicknameInput.trim()}`);
+            setIsModalOpen(false);
         }
-    };
-
-    const handleKeyDown = (event, type) => {
-        // IME 입력 상태를 확인하여 조합 중일 때 전송하지 않음
-        if (event.key === 'Enter' && event.nativeEvent.isComposing === false) {
-            const content = event.target.value;
-            sendMessage(content, type);
-
-            // 상태 업데이트
-            if (type === "agenda") setAgenda(content);
-            else if (type === "notes") setNotes(content);
-            else if (type === "results") setResults(content);
-        }
-    };
-
-    const handleChange = (event, type) => {
-        const updatedText = event.target.value;
-
-        if (type === "agenda") setAgenda(updatedText);
-        else if (type === "notes") setNotes(updatedText);
-        else if (type === "results") setResults(updatedText);
-
-        // WebSocket 메시지 전송 지연 처리
-        if (debounceTimeout.current) clearTimeout(debounceTimeout.current);
-
-        debounceTimeout.current = setTimeout(() => {
-            sendMessage(updatedText, type);
-        }, 200); // 입력 후 200ms 뒤 전송
-    };
+    };    
 
     return (
-        <div className="container">
-            <h1>회의록📋</h1>
-            <div className="meeting-info">
-                <label>
-                    <strong>📅 회의 날짜:</strong>
-                    <input
-                        type="date"
-                        value={meetingDate}
-                        onChange={(e) => setMeetingDate(e.target.value)}
-                    />
-                </label>
+        <div className="collaborative-editor">
+            {/* 참여 메시지 섹션 */}
+            <section className="participants-section">
+                <h4>참여 메시지</h4>
+                <ul>
+                    {nicknameMessages.map((msg, index) => (
+                        <li key={index}>{msg}</li>
+                    ))}
+                </ul>
                 <br></br>
-                <label>
-                    <strong>👥 참석자 명단:</strong>
-                    <input
-                        type="text"
-                        placeholder="참석자 이름 입력 (예: 홍길동, 김철수)"
-                        value={attendees}
-                        onChange={(e) => setAttendees(e.target.value)}
+            </section>
+
+            {/* 회의록 섹션 */}
+            <section className="editor-section">
+                <h1>회의록📋</h1>
+                <div className="meeting-info">
+                    <label>
+                        <strong>📅 회의 날짜:</strong>
+                        <input
+                            type="date"
+                            value={meetingDate}
+                            onChange={(e) => setMeetingDate(e.target.value)}
+                        />
+                    </label>
+                </div>
+
+                <div className="agenda-section">
+                    <h3>🌱 회의 안건</h3>
+                    <textarea
+                        value={agenda}
+                        onChange={(e) => setAgenda(e.target.value)}
+                        placeholder="회의 안건을 여기에 작성하세요!"
+                        rows="6"
                     />
-                </label>
-            </div>
-            <div className="agenda-section">
-                <h3>🌱 회의 안건</h3>
-                <textarea
-                    data-type="agenda"
-                    value={agenda}
-                    onChange={(e) => handleChange(e, "agenda")}
-                    onKeyDown={(e) => handleKeyDown(e, "agenda")}
-                    placeholder="회의 안건을 여기에 작성하세요!"
-                    rows="6"
-                />
-            </div>
-            <div className="notes-section">
-                <h3>✏️ 회의록</h3>
-                <textarea
-                    data-type="notes"
-                    value={notes}
-                    onChange={(e) => handleChange(e, "notes")}
-                    onKeyDown={(e) => handleKeyDown(e, "notes")}
-                    placeholder="회의 내용을 여기에 작성하세요!"
-                    rows="12"
-                />
-            </div>
-            <div className="results-section">
-                <h3>☑️ 회의 결과</h3>
-                <textarea
-                    data-type="results"
-                    value={results}
-                    onChange={(e) => handleChange(e, "results")}
-                    onKeyDown={(e) => handleKeyDown(e, "results")}
-                    placeholder="회의 결과를 여기에 작성하세요!"
-                    rows="12"
-                />
-            </div>
-            <button className="save-button">저장하기</button>
+                </div>
+
+                <div className="notes-section">
+                    <h3>✏️ 회의록</h3>
+                    <textarea
+                        value={notes}
+                        onChange={(e) => setNotes(e.target.value)}
+                        placeholder="회의 내용을 여기에 작성하세요!"
+                        rows="12"
+                    />
+                </div>
+
+                <div className="results-section">
+                    <h3>☑️ 회의 결과</h3>
+                    <textarea
+                        value={results}
+                        onChange={(e) => setResults(e.target.value)}
+                        placeholder="회의 결과를 여기에 작성하세요!"
+                        rows="12"
+                    />
+                </div>
+                <button className="save-button">저장하기</button>
+            </section>
+
+            {/* 닉네임 설정 모달 */}
+            {isModalOpen && (
+                <div className="modal">
+                    <div className="modal-content">
+                        <h2>Enter your Name!</h2>
+                        <input
+                            type="text"
+                            value={nicknameInput}
+                            onChange={(e) => setNicknameInput(e.target.value)}
+                            placeholder="회의에 사용될 이름을 입력하세요."
+                        />
+                        <button onClick={handleModalSubmit}>확인</button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/client/src/services/MeetingSocket/CollaborativeEditor.js
+++ b/client/src/services/MeetingSocket/CollaborativeEditor.js
@@ -146,6 +146,7 @@ function CollaborativeEditor() {
                         <li key={nicknameMessages.length + index}>{message}</li>
                     ))}
                 </ul>
+                <br></br>
                 <button className="leave-button" onClick={handleLeaveMeeting}>나가기</button>
             </section>
 

--- a/server/src/main/java/com/example/server/MeetingSocket/Service/WebSocketMeeting.java
+++ b/server/src/main/java/com/example/server/MeetingSocket/Service/WebSocketMeeting.java
@@ -14,52 +14,52 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-// websoket 서버 구현
-// controller는 RestAPI 이므로 http 요청-응답 상태이다.
-// 그러므로 양방향 통신인 웹소켓에서는 http가 아니라 ws를 사용하기 때문에 controller가 필요없다.
-// 따라서 service 패키지에서 바로 데이터를 주고 받으므로 이 패키지에 두는 것이 맞음
 @Service
 @ServerEndpoint("/socket/meeting")
 public class WebSocketMeeting {
-    // websocket에 연결된 클라이언트 세션을 저장하는 동기화된 Set
-    private static Set<Session> clients = Collections.synchronizedSet(new HashSet<Session>());
-    // 로깅을 위한 Logger 인스턴스
+    private static Set<Session> clients = Collections.synchronizedSet(new HashSet<>());
+    private static Set<String> nicknames = Collections.synchronizedSet(new HashSet<>());  // 닉네임 목록
     private static Logger logger = LoggerFactory.getLogger(WebSocketMeeting.class);
 
-    // 클라이언트가 WebSocket에 연결될 때 호출되는 메서드
-    // 세션 정보를 받음
     @OnOpen
     public void onOpen(Session session) {
         logger.info("open session : {}, clients={}", session.toString(), clients);
 
-        // 새로운 세션을 clients sets에 추가
-        if(!clients.contains(session)) {
+        // 새로운 세션을 clients set에 추가
+        if (!clients.contains(session)) {
             clients.add(session);
             logger.info("session open : {}", session);
-        }else{
+        } else {
             logger.info("이미 연결된 session");
         }
     }
 
-    // 클라이언트가 메시지를 보낼 때 호출되는 메서드
-    // 클라이언트가 보낸 메시지와 세션정보, IOException 발생가능을 받음
     @OnMessage
     public void onMessage(String message, Session session) throws IOException {
         logger.info("receive message : {}", message);
 
-        // 모든 클라이언트에게 메시지를 전송
-        for (Session s : clients) {
-            logger.info("send data : {}", message);
-            s.getBasicRemote().sendText(message); // 메시지를 타입별로 전송
+        // 닉네임을 설정할 때 (입력한 닉네임을 세션에 저장)
+        if (message.startsWith("nickname:")) {
+            String nickname = message.substring(9);  // "nickname:" 뒤의 내용이 닉네임
+            nicknames.add(nickname);
+            logger.info("New nickname added: {}", nickname);
+
+            // 모든 클라이언트에게 닉네임 목록을 전송
+            for (Session s : clients) {
+                s.getBasicRemote().sendText("nicknames:" + String.join(", ", nicknames));
+            }
+        } else {
+            // 회의록에 대한 메시지 처리 (기존의 메시지 처리 방식 유지)
+            for (Session s : clients) {
+                s.getBasicRemote().sendText(message);
+            }
         }
     }
 
-    // 클라이언트와의 WebSocket 연결이 닫힐 때 호출되는 메서드
-    // 연결이 종료된 클라이언트의 세션 정보를 받음
     @OnClose
     public void onClose(Session session) {
         logger.info("session close : {}", session);
-        // 연결이 종료된 세션을 client Sets에서 제거
+        // 연결이 종료된 세션을 clients set에서 제거
         clients.remove(session);
     }
 }

--- a/server/src/main/java/com/example/server/MeetingSocket/Service/WebSocketMeeting.java
+++ b/server/src/main/java/com/example/server/MeetingSocket/Service/WebSocketMeeting.java
@@ -11,55 +11,77 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @ServerEndpoint("/socket/meeting")
 public class WebSocketMeeting {
-    private static Set<Session> clients = Collections.synchronizedSet(new HashSet<>());
-    private static Set<String> nicknames = Collections.synchronizedSet(new HashSet<>());  // 닉네임 목록
+    private static Set<Session> clients = Collections.synchronizedSet(ConcurrentHashMap.newKeySet());
+    private static Map<Session, String> sessionNicknameMap = new ConcurrentHashMap<>();
     private static Logger logger = LoggerFactory.getLogger(WebSocketMeeting.class);
 
     @OnOpen
     public void onOpen(Session session) {
-        logger.info("open session : {}, clients={}", session.toString(), clients);
-
-        // 새로운 세션을 clients set에 추가
-        if (!clients.contains(session)) {
-            clients.add(session);
-            logger.info("session open : {}", session);
-        } else {
-            logger.info("이미 연결된 session");
-        }
+        logger.info("New session connected: {}", session);
+        clients.add(session);
     }
 
     @OnMessage
     public void onMessage(String message, Session session) throws IOException {
-        logger.info("receive message : {}", message);
+        logger.info("Message received: {}", message);
 
-        // 닉네임을 설정할 때 (입력한 닉네임을 세션에 저장)
         if (message.startsWith("nickname:")) {
-            String nickname = message.substring(9);  // "nickname:" 뒤의 내용이 닉네임
-            nicknames.add(nickname);
+            String nickname = message.substring(9).trim();
+
+            if (sessionNicknameMap.containsValue(nickname)) {
+                session.getBasicRemote().sendText("error:이미 사용 중인 닉네임입니다.");
+                return;
+            }
+
+            sessionNicknameMap.put(session, nickname);
             logger.info("New nickname added: {}", nickname);
 
-            // 모든 클라이언트에게 닉네임 목록을 전송
-            for (Session s : clients) {
-                s.getBasicRemote().sendText("nicknames:" + String.join(", ", nicknames));
-            }
+            // 브로드캐스트로 닉네임 업데이트
+            broadcast("nicknames:" + String.join(", ", sessionNicknameMap.values()));
+
+        } else if (message.startsWith("leave:")) {
+            handleClientLeave(session);
         } else {
-            // 회의록에 대한 메시지 처리 (기존의 메시지 처리 방식 유지)
-            for (Session s : clients) {
-                s.getBasicRemote().sendText(message);
-            }
+            broadcast(message); // 일반 메시지 브로드캐스팅
         }
     }
 
     @OnClose
     public void onClose(Session session) {
-        logger.info("session close : {}", session);
-        // 연결이 종료된 세션을 clients set에서 제거
-        clients.remove(session);
+        logger.info("Session closed: {}", session);
+        handleClientLeave(session);
+    }
+
+    private void handleClientLeave(Session session) {
+        String nickname = sessionNicknameMap.remove(session);
+        if (nickname != null) {
+            logger.info("Client left: {}", nickname);
+            clients.remove(session);
+
+            try {
+                broadcast("leave:" + nickname + "님이 회의에서 나갔습니다.");
+                broadcast("nicknames:" + String.join(", ", sessionNicknameMap.values()));
+            } catch (IOException e) {
+                logger.error("Error broadcasting leave message", e);
+            }
+        }
+    }
+
+    private void broadcast(String message) throws IOException {
+        synchronized (clients) {
+            for (Session client : clients) {
+                if (client.isOpen()) {
+                    client.getBasicRemote().sendText(message);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🌱 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨ 
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

## 🔗 연관된 이슈
### [#6](https://github.com/janghw0126/Real-Time-Collaborative-Editor/issues/6)

## 📝 변경 사항
- 회의록 입장 시, 회의에 사용될 닉네임을 입력합니다.
![image](https://github.com/user-attachments/assets/176bbd0d-7ec4-4d20-8965-0fd63534e145)
- 사용하려는 닉네임이 이미 사용 중인 닉네임이라면, 중복된다는 경고창이 뜹니다.
![image](https://github.com/user-attachments/assets/9a53c161-3fe2-44f5-be83-2dc7def48d93)
- 닉네임을 입력한 후 입장 시, 실시간으로 회의 참여 상태가 해당 컴포넌트에 기록됩니다.
![image](https://github.com/user-attachments/assets/596c1486-54a2-46ff-bc03-550ade53a262)
- 회의록 나가기 버튼 클릭 시, 회의록 퇴장 메시지과 함께 해당 참여자의 소켓이 닫힙니다.
![image](https://github.com/user-attachments/assets/117c6006-97dd-4e12-b7df-294aec0f26e6)
- 현재 입장해있는 참여자들의 목록을 나타냅니다.
![image](https://github.com/user-attachments/assets/73b90ea8-9735-4d03-95bc-4744785cdad3)
![image](https://github.com/user-attachments/assets/f72af661-55eb-4d3e-9519-543f9aab62e9)

## ✒️ 이슈 사항
- 나가기 버튼이 아닌, 새로고침 클릭 시에는 해당 참여자 소켓이 닫히고 닉네임 입력 모달 창으로 다시 돌아갑니다.
- 여기서 닉네임을 다시 입력하여 재입장 할 경우, 현재 참여자들의 목록과 회의 참여 상태만 렌더링 되고, 나간 참여자들의 상태메시지는 렌더링 되지 않습니다.
- -> 애초에 서버가 현재 남아있는 참여자들의 목록만 회의 참여 상태 메시지로 브로드캐스트하고, 소켓이 닫힐 시에 세션을 삭제하고 기록이 남지 않게 하였으므로 나간 사람들의 메시지는 기록되지 않습니다.
- 그래서 회의록에 나간 사람들과 남아있는 사람들의 회의 참여 상태 컴포넌트가 다른 상태입니다.
